### PR TITLE
Enabling HTTP to be a secure route

### DIFF
--- a/openshift/gitops/manifests/rfe/httpd/base/route.yaml
+++ b/openshift/gitops/manifests/rfe/httpd/base/route.yaml
@@ -7,6 +7,9 @@ metadata:
     app.kubernetes.io/instance: httpd
   name: httpd
 spec:
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
   port:
     targetPort: 8080-tcp
   to:


### PR DESCRIPTION
Enabling HTTP to be a secure route

Insecure routes can set the `inst.noverifyssl` boot argument