### PR TITLE
Adding sync-{options,wave} to BackingStore resource.

### DIFF
--- a/openshift/gitops/manifests/configs/ocs/base/noobaa-pv-backing-store.yaml
+++ b/openshift/gitops/manifests/configs/ocs/base/noobaa-pv-backing-store.yaml
@@ -16,5 +16,4 @@ spec:
     resources:
       requests:
         storage: 50Gi
-    storageClass: thin
   type: pv-pool


### PR DESCRIPTION
For net new deployments, Argo CD will fail to sync the OCS application.