### PR TITLE
Adding Quay chart with subscription

### DIFF
--- a/charts/quay/templates/quayappsubscription.yaml
+++ b/charts/quay/templates/quayappsubscription.yaml
@@ -1,0 +1,15 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: quay-operator
+  namespace: {{ template "common.names.namespace" $ }}
+  labels:
+    {{- include "common.labels.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.subscription.annotations | nindent 4 }}  
+spec:
+  channel: quay-v3.5
+  installPlanApproval: Automatic
+  name: quay-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/charts/quay/templates/quayregistry.yaml
+++ b/charts/quay/templates/quayregistry.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ template "common.names.namespace" $ }}
   labels:
     {{- include "common.labels.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.quayRegistryCR.annotations | nindent 4 }}
 spec:
   components:
 {{- range .Values.quay.components }}

--- a/charts/quay/values.yaml
+++ b/charts/quay/values.yaml
@@ -17,3 +17,12 @@ quay:
       managed: true
     - kind: route
       managed: true
+
+subscription:
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-failed
+
+quayRegistryCR:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/helm/testing/quay/quay.yaml
+++ b/helm/testing/quay/quay.yaml
@@ -1,0 +1,15 @@
+---
+common:
+  repoURL: https://github.com/redhat-cop/rhel-edge-automation-arch.git
+  targetRevision: helm-migration
+  project: default
+  destinationNamespace: openshift-operators
+  server: https://kubernetes.default.svc
+  prune: true
+  chartPath: charts/quay
+  selfHeal: true
+
+charts:
+  quay:
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
Adds the subscription to the quay chart and also defines a template for the app-manager to trigger the quay chart deployment.

@sabre1041 I have not been able to test this in my environment due to dependencies in the quay deployment. If you can test it in your environment, please give it a try and let me know how it goes.

This is the app manifest generated pointing to my branch:

```
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: quay
  namespace: openshift-gitops
spec:
  destination:
    namespace: openshift-operators
    server: https://kubernetes.default.svc
  project: default
  source:
    path: charts/quay
    repoURL: https://github.com/jordigilh/rhel-edge-automation-arch.git
    targetRevision: quay_chart
  syncPolicy:
    automated:
      prune: true
      selfHeal: true
    syncOptions:
      - CreateNamespace=true
```

/Jordi