### PR TITLE
adding machineset chart

### DIFF
--- a/charts/machineset/Chart.yaml
+++ b/charts/machineset/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: cnv
+description: OpenShift Virtualization
+type: application
+version: 0.1.0
+dependencies:
+  - name: common
+    version: 0.1.0
+    repository: file://../common

--- a/charts/machineset/templates/aws-machineset-ansible-job.yaml
+++ b/charts/machineset/templates/aws-machineset-ansible-job.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    {{- include "common.labels.labels" . | nindent 4 }}
+    {{- toYaml .Values.ansibleJob.labels | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.ansibleJob.annotations | nindent 4 }}
+  name: aws-machineset-ansible-job
+  namespace: {{ template "common.names.namespace" $ }}
+spec:
+  template:
+    spec:
+      activeDeadlineSeconds: 1200
+      containers:
+        - image: image-registry.openshift-image-registry.svc:5000/rfe/ansible-rfe-runner:latest
+          env:
+            - name: GIT_DIRECTORY
+              value: "/tmp/git/rhel-edge-automation-arch"
+            - name: GIT_URL
+              value: "https://github.com/redhat-cop/rhel-edge-automation-arch.git"
+            - name: ANSIBLE_PLAYBOOK
+              value: "ansible/playbooks/machineset-aws.yaml"
+            - name: ANSIBLE_CONFIG
+              value: $GIT_DIRECTORY/ansible/ansible.cfg
+          command:
+            - /bin/bash
+            - -c
+            - |
+              mkdir -p $GIT_DIRECTORY
+              git clone $GIT_URL $GIT_DIRECTORY
+              ansible-galaxy collection install -r $GIT_DIRECTORY/ansible/collections/requirements.yaml
+              ansible-playbook $GIT_DIRECTORY/$ANSIBLE_PLAYBOOK
+          imagePullPolicy: Always
+          name: ansible-rfe-runner
+      dnsPolicy: ClusterFirst
+      restartPolicy: OnFailure
+      serviceAccount: aws-machineset
+      serviceAccountName: aws-machineset
+      terminationGracePeriodSeconds: 30

--- a/charts/machineset/templates/aws-machineset-infrastructures-clusterrole.yaml
+++ b/charts/machineset/templates/aws-machineset-infrastructures-clusterrole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: aws-machineset-infrastructures
+  labels:
+    {{- include "common.labels.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - infrastructures
+    verbs:
+      - get
+      - list

--- a/charts/machineset/templates/aws-machineset-infrastructures-clusterrolebinding.yaml
+++ b/charts/machineset/templates/aws-machineset-infrastructures-clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: aws-machineset-infrastructures
+  labels:
+    {{- include "common.labels.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aws-machineset-infrastructures
+subjects:
+- kind: ServiceAccount
+  name: aws-machineset
+  namespace: {{ template "common.names.namespace" $ }}

--- a/charts/machineset/templates/aws-machineset-machinesets-role.yaml
+++ b/charts/machineset/templates/aws-machineset-machinesets-role.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: aws-machineset-machinesets
+  namespace: openshift-machine-api
+  labels:
+    {{- include "common.labels.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - machine.openshift.io
+    resources:
+      - machinesets
+    verbs:
+      - create
+      - patch
+      - list
+      - update
+      - get

--- a/charts/machineset/templates/aws-machineset-machinesets-rolebinding.yaml
+++ b/charts/machineset/templates/aws-machineset-machinesets-rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: aws-machineset-machinesets
+  namespace: openshift-machine-api
+  labels:
+    {{- include "common.labels.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: aws-machineset-machinesets
+subjects:
+  - kind: ServiceAccount
+    name: aws-machineset
+    namespace: {{ template "common.names.namespace" $ }}

--- a/charts/machineset/templates/aws-machineset-serviceaccount.yaml
+++ b/charts/machineset/templates/aws-machineset-serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aws-machineset
+  namespace: {{ template "common.names.namespace" $ }}
+  labels:
+    {{- include "common.labels.labels" . | nindent 4 }}

--- a/charts/machineset/values.yaml
+++ b/charts/machineset/values.yaml
@@ -1,0 +1,7 @@
+
+
+ansibleJob:
+  labels:
+    run: aws-machineset-ansible-job
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"

--- a/helm/testing/machineset/machineset.yaml
+++ b/helm/testing/machineset/machineset.yaml
@@ -1,0 +1,13 @@
+---
+common:
+  repoURL: https://github.com/redhat-cop/rhel-edge-automation-arch.git
+  targetRevision: helm-migration
+  project: default
+  destinationNamespace: rfe
+  server: https://kubernetes.default.svc
+  prune: true
+  chartPath: charts/machineset
+  selfHeal: true
+
+charts:
+  machineset: {}


### PR DESCRIPTION
Adding manifests for `machineset`

@sabre1041 can you take a look? I've removed the annotation `argocd.argoproj.io/sync-wave: "10"` from the job, I don't think it's needed now, but let me know if you'd like to put it back as a helm hook weight. 