### PR TITLE
Adding HTTPD chart

### DIFF
--- a/charts/httpd/Chart.yaml
+++ b/charts/httpd/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: httpd
+description: RFE Httpd
+type: application
+version: 0.1.0
+dependencies:
+  - name: common
+    version: 0.1.0
+    repository: file://../common

--- a/charts/httpd/templates/deployment.yaml
+++ b/charts/httpd/templates/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"{{ .Values.buildConfig.output.imageStreamTagName }}","namespace":"{{- template "common.names.namespace" $ }}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"httpd\")].image"}]'
+  labels:
+    {{- include "common.labels.labels" . | nindent 4 }}
+    {{- toYaml .Values.service.labels | nindent 4 }}
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ template "common.names.namespace" $ }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      deployment: httpd
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        deployment: httpd
+    spec:
+      containers:
+        - image: " "
+          name: httpd
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+            - containerPort: 8443
+              protocol: TCP
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "500m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          volumeMounts:
+            - mountPath: /var/www/html
+              name: data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: httpd

--- a/charts/httpd/templates/httpd-ostree-buildconfig.yaml
+++ b/charts/httpd/templates/httpd-ostree-buildconfig.yaml
@@ -1,0 +1,51 @@
+kind: BuildConfig
+apiVersion: build.openshift.io/v1
+metadata:
+  name: {{ .Values.buildConfig.name }}
+  namespace: {{ template "common.names.namespace" $ }}
+  labels:
+    {{- include "common.labels.labels" . | nindent 4 }}
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: {{ .Values.buildConfig.output.imageStreamTagName }}
+  postCommit: {}
+  resources: {}
+  runPolicy: Serial
+  source:
+    dockerfile: |
+      FROM registry.redhat.io/rhel8/httpd-24
+      USER 0
+      COPY ./etc-pki-entitlement /etc/pki/entitlement
+      COPY ./rhsm-conf /etc/rhsm
+      COPY ./rhsm-ca /etc/rhsm/ca
+      RUN rm /etc/rhsm-host && \
+        dnf repolist --disablerepo=* && \
+        subscription-manager repos {{- range .Values.buildConfig.enableRepositories }} --enable {{ . }} {{- end}} && \
+        dnf update -y && \
+        dnf install -y ostree && \
+        rm -rf /etc/pki/entitlement && \
+        rm -rf /etc/rhsm
+      USER 1001
+    secrets:
+    - destinationDir: etc-pki-entitlement
+      secret:
+        name: etc-pki-entitlement
+    - destinationDir: rhsm-ca
+      secret:
+        name: rhsm-ca
+    - destinationDir: rhsm-conf
+      secret:
+        name: rhsm-conf
+    type: Dockerfile
+  strategy:
+    type: Docker
+    dockerStrategy:
+      from:
+        kind: "ImageStreamTag"
+        name: {{ .Values.buildConfig.strategy.dockerStrategyFrom.name | quote }}
+        namespace: openshift
+  successfulBuildsHistoryLimit: 5
+  triggers:
+  - type: ConfigChange

--- a/charts/httpd/templates/httpd-ostree-imagestream.yaml
+++ b/charts/httpd/templates/httpd-ostree-imagestream.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: {{ .Values.buildConfig.name }}
+  namespace: {{ template "common.names.namespace" $ }}
+  labels:
+    {{- include "common.labels.labels" . | nindent 4 }}
+spec: {}

--- a/charts/httpd/templates/pvc.yaml
+++ b/charts/httpd/templates/pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ template "common.names.namespace" $ }}
+  labels:
+    {{- include "common.labels.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+  volumeMode: Filesystem

--- a/charts/httpd/templates/route.yaml
+++ b/charts/httpd/templates/route.yaml
@@ -1,0 +1,18 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    {{- include "common.labels.labels" . | nindent 4 }}
+    {{- toYaml .Values.service.labels | nindent 4 }}
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ template "common.names.namespace" $ }}
+spec:
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  port:
+    targetPort: 8080-tcp
+  to:
+    kind: Service
+    name: {{ template "common.names.fullname" . }}
+    weight: 100

--- a/charts/httpd/templates/service.yaml
+++ b/charts/httpd/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{- include "common.labels.labels" . | nindent 4 }}
+    {{- toYaml .Values.service.labels | nindent 4 }}
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ template "common.names.namespace" $ }}
+spec:
+  ports:
+    - name: 8080-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    - name: 8443-tcp
+      port: 8443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    deployment: {{ template "common.names.fullname" . }}

--- a/charts/httpd/values.yaml
+++ b/charts/httpd/values.yaml
@@ -1,0 +1,17 @@
+service:
+  labels:
+    app: httpd
+    app.kubernetes.io/component: httpd
+    app.kubernetes.io/instance: httpd
+
+buildConfig:
+  name: httpd-ostree
+  strategy:
+    dockerStrategyFrom:
+      name: httpd:2.4-el8
+  output:
+    imageStreamTagName:
+       httpd-ostree:latest
+  enableRepositories:
+  - rhel-8-for-x86_64-baseos-rpms
+  - rhel-8-for-x86_64-appstream-rpms

--- a/helm/testing/httpd/httpd.yaml
+++ b/helm/testing/httpd/httpd.yaml
@@ -1,0 +1,14 @@
+---
+common:
+  repoURL: https://github.com/redhat-cop/rhel-edge-automation-arch.git
+  targetRevision: helm-migration
+  project: default
+  destinationNamespace: rfe
+  server: https://kubernetes.default.svc
+  prune: true
+  chartPath: charts/httpd
+  selfHeal: true
+charts:
+  httpd:
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
Adds the httpd manifests found here in a helm chart. I've parametrized the docker image name, currently `httpd-2.4` and the image stream tag, currently `httpd:2.4-el8`, to make it easier to update in the future. 

@sabre1041 @nasx please take a look.