### PR TITLE
Fixes wrong target namespace for CNV operatorGroup

### DIFF
--- a/charts/cnv/templates/operatorgroup.yaml
+++ b/charts/cnv/templates/operatorgroup.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: {{ template "common.names.namespace" $ }}
 spec:
   targetNamespaces:
-    - {{ .Values.namespace }}
+    - {{ template "common.names.namespace" . }}


### PR DESCRIPTION
While running the cnv chart, I found an issue in the operatorGroup that the targetNamespace value was not correctly defined. This PR fixes that.

@sabre1041 @nasx please review at your convenience. I know that we'll probably end up splitting the operator from the related CRs, but in the meanwhile this PR can stay there just in case we want to keep the current approach or need to test it.

/Jordi