### PR TITLE
Fix/serviceaccount imagepullsecret drift

### DIFF
--- a/openshift/gitops/manifests/bootstrap/argocd/base/argocd.yaml
+++ b/openshift/gitops/manifests/bootstrap/argocd/base/argocd.yaml
@@ -50,4 +50,10 @@ spec:
         hs.status = "Progressing"
         hs.message = "Waiting for Subscription to complete."
         return hs
+    ServiceAccount:
+      ignoreDifferences: |
+        jsonPointers:
+        - /imagePullSecrets
+        - /secrets
+      
 


### PR DESCRIPTION
Fixes an issue with ServiceAccounts caused by the drift in the manifest spec's `imagePullSecret` and `secrets` fields that triggers a recurring sync in argoCD. 

From the application point of view, it is in constant `out-of-sync` status while it attempts to synchronize. 
![image](https://user-images.githubusercontent.com/19480463/141830513-04dc58c2-c540-4547-b107-1d753491576b.png)
![image](https://user-images.githubusercontent.com/19480463/141830463-191f46d5-ad6e-476f-98f6-ea5df5ab20cc.png)

With this change, ArgoCD will ignore the `pullImageSecret` and `secrets` difference.
![image](https://user-images.githubusercontent.com/19480463/141830695-675f4f9b-00a9-4aca-b468-2b15dcae7786.png)

@sabre1041 @nasx please review. I needed only `imagePullSecrets`, but I thought adding `secrets` might be also worth it since it can also be a cause of out-of-sync in other cases. Let me know if you want me to narrow it to only `imagePullSecrets`. 

There is another way to approach this, and that's to define this specifically to an `Application` manifest, rather than globally in ArgoCD, just by adding this snippet of code to the `Application` manifest:
```
  ignoreDifferences:
    - jsonPointers:
        - /imagePullSecrets
        - /secrets
      kind: ServiceAccount
```

Let me know which one you prefer.