### PR TITLE
Adds RBAC application chart values

### DIFF
--- a/helm/testing/rbac/rbac.yaml
+++ b/helm/testing/rbac/rbac.yaml
@@ -1,0 +1,14 @@
+---
+common:
+  repoURL: https://github.com/redhat-cop/rhel-edge-automation-arch.git
+  targetRevision: helm-migration
+  project: default
+  destinationNamespace: rfe
+  server: https://kubernetes.default.svc
+  prune: true
+  chartPath: charts/rbac
+  selfHeal: true
+charts:
+  rbac:
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
Adds the application chart values for the RBAC chart in `helm/testing/`. The chart is already in `charts/rbac`, but the link was missing to generate the `Application` manifest via the `application-manager` chart.

@sabre1041 @nasx Please review. 