### PR TITLE
Adding Group Sync operator helm chart

### DIFF
--- a/charts/operator/templates/operatorgroup.yaml
+++ b/charts/operator/templates/operatorgroup.yaml
@@ -7,6 +7,10 @@ metadata:
   namespace: {{ template "common.names.namespace" $ }}
   labels:
     {{- include "common.labels.labels" . | nindent 4 }}
+  {{- if .Values.operatorgroup.annotations }}
+  annotations:
+    {{- toYaml .Values.operatorgroup.annotations | nindent 4 }}
+  {{- end }}
 spec:
   targetNamespaces:
     - {{ template "common.names.namespace" . }}

--- a/charts/operator/templates/subscription.yaml
+++ b/charts/operator/templates/subscription.yaml
@@ -11,3 +11,7 @@ spec:
   name: {{ required "Operator name is required!" .Values.operator.name }}
   source: {{ required "Operator source is required!" .Values.operator.source }}
   sourceNamespace: {{ required "Operator source namespace is required!" .Values.operator.sourceNamespace }}
+{{- if .Values.config }}
+  config:
+  {{- tpl (toYaml .Values.config) $ | nindent 4 }}
+{{- end }}

--- a/helm/testing/operators/group-sync-operator.yaml
+++ b/helm/testing/operators/group-sync-operator.yaml
@@ -1,0 +1,14 @@
+# install to group-sync-operator namespace
+---
+operator:
+  channel: "alpha"
+  installPlanApproval: Automatic
+  name: "group-sync-operator"
+  source: "community-operators"
+  sourceNamespace: "openshift-marketplace"
+operatorgroup:
+  create: true
+config:
+  env:
+  - name: WATCH_NAMESPACE
+    value: ""


### PR DESCRIPTION
Adds the group-sync operator. I've modified the operator chart to add the ability to specify extra configuration and define annotations in the `OperatorGroup` to match the current manifest specification for the group-sync operator:

https://github.com/redhat-cop/rhel-edge-automation-arch/blob/1588add318c58880b6e35c1a0b90d5283ffeb030/openshift/gitops/clusters/overlays/shared/configs/auth/group-sync-operator-operatorgroup.yaml#L4-L5

and 

https://github.com/redhat-cop/rhel-edge-automation-arch/blob/1588add318c58880b6e35c1a0b90d5283ffeb030/openshift/gitops/clusters/overlays/shared/configs/auth/group-sync-operator-subscription.yaml#L12-L15


@sabre1041 @nasx please review.