### PR TITLE
Fixes quay subscription deletion

### DIFF
--- a/charts/quay/values.yaml
+++ b/charts/quay/values.yaml
@@ -21,7 +21,6 @@ quay:
 subscription:
   annotations:
     "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": hook-failed
 
 quayRegistryCR:
   annotations:


### PR DESCRIPTION
Removes helm hook to delete the subscription in case of failure. If deleted, things go awry as the csv and installPlan are still processing the request.

I've managed to get it to work just fine when I removed this annotation.

@sabre1041 @nasx please review at your discretion.