### PR TITLE
Extract git repo info in quay setup job

### DIFF
--- a/charts/quay/templates/quay-setup-job.yaml
+++ b/charts/quay/templates/quay-setup-job.yaml
@@ -19,17 +19,19 @@ spec:
             - name: GIT_DIRECTORY
               value: "/tmp/git/rhel-edge-automation-arch"
             - name: GIT_URL
-              value: "https://github.com/redhat-cop/rhel-edge-automation-arch.git"
+              value: {{ .Values.setupJob.gitRepository | quote }}
             - name: ANSIBLE_PLAYBOOK
               value: "ansible/playbooks/quay-setup.yaml"
             - name: ANSIBLE_CONFIG
               value: $GIT_DIRECTORY/ansible/ansible.cfg
+            - name: GIT_BRANCH
+              value: {{ .Values.setupJob.gitBranch | quote }}
           command:
             - /bin/bash
             - -c
             - |
               mkdir -p $GIT_DIRECTORY
-              git clone $GIT_URL $GIT_DIRECTORY
+              git clone -b $GIT_BRANCH $GIT_URL $GIT_DIRECTORY
               ansible-galaxy collection install -r $GIT_DIRECTORY/ansible/collections/requirements.yaml
               ansible-playbook $GIT_DIRECTORY/$ANSIBLE_PLAYBOOK
           imagePullPolicy: Always

--- a/charts/quay/values.yaml
+++ b/charts/quay/values.yaml
@@ -25,3 +25,7 @@ subscription:
 quayRegistryCR:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+setupJob:
+  gitRepository: https://github.com/redhat-cop/rhel-edge-automation-arch.git
+  gitBranch: main


### PR DESCRIPTION
Extracts the git repository information from the ansible setup job for quay into the helm variables file.

@sabre1041 @nasx please review.