### PR TITLE
Adds retry to wait for the Quay API

### DIFF
--- a/ansible/playbooks/quay-setup.yaml
+++ b/ansible/playbooks/quay-setup.yaml
@@ -111,6 +111,8 @@
         - quay_status.status == 200
         - quay_status.json.data.services is defined
         - quay_status.json.data.services | dict2items | rejectattr('value', 'equalto', True) | list | count == 0
+      delay: 10
+      retries: 60
 
     - name: Create RFE User
       vars:


### PR DESCRIPTION
Adds a retry when waiting for the quay route to be ready. Worked like a charm when I tested it:

```
TASK [Wait for Quay API] *******************************************************
Thursday 18 November 2021  00:16:41 +0000 (0:00:00.074)       0:01:29.753 ***** 
FAILED - RETRYING: Wait for Quay API (120 retries left).
FAILED - RETRYING: Wait for Quay API (119 retries left).
FAILED - RETRYING: Wait for Quay API (118 retries left).
FAILED - RETRYING: Wait for Quay API (117 retries left).
FAILED - RETRYING: Wait for Quay API (116 retries left).
FAILED - RETRYING: Wait for Quay API (115 retries left).
FAILED - RETRYING: Wait for Quay API (114 retries left).
FAILED - RETRYING: Wait for Quay API (113 retries left).
FAILED - RETRYING: Wait for Quay API (112 retries left).
ok: [localhost]
```

@sabre1041 @nasx targeting `main` branch for this PR.