### PR TITLE
Add post-install hook delete for nexus job

### DIFF
--- a/charts/nexus/templates/nexus-setup-job.yaml
+++ b/charts/nexus/templates/nexus-setup-job.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ template "common.names.namespace" $ }}
   labels:
     {{- include "common.labels.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.setupJob.annotations | nindent 4}}
 spec:
   template:
     spec:

--- a/charts/nexus/templates/nexus-setup-role.yaml
+++ b/charts/nexus/templates/nexus-setup-role.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ template "common.names.namespace" $ }}
   labels:
     {{- include "common.labels.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.setupJob.annotations | nindent 4}}
 rules:
   - apiGroups:
       - ""

--- a/charts/nexus/templates/nexus-setup-rolebinding.yaml
+++ b/charts/nexus/templates/nexus-setup-rolebinding.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ template "common.names.namespace" $ }}
   labels:
     {{- include "common.labels.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.setupJob.annotations | nindent 4}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -14,3 +16,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ $setupJobName }}
     namespace: {{ template "common.names.namespace" $ }}
+s

--- a/charts/nexus/templates/nexus-setup-serviceaccount.yaml
+++ b/charts/nexus/templates/nexus-setup-serviceaccount.yaml
@@ -6,3 +6,5 @@ metadata:
   namespace: {{ template "common.names.namespace" $ }}
   labels:
     {{- include "common.labels.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.setupJob.annotations | nindent 4}}

--- a/charts/nexus/values.yaml
+++ b/charts/nexus/values.yaml
@@ -41,3 +41,8 @@ setup:
     repository: openshift4/ose-cli
     version: v4.6
     imagePullPolicy: IfNotPresent
+
+setupJob:
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded


### PR DESCRIPTION
Adds the post-install hook and the hook delete policy to remove the nexus setup job and its related objects after it has completed its task.

@sabre1041 @nasx please review.