### PR TITLE
Fix/quay namespace mismatch

### DIFF
--- a/charts/quay/templates/quay-setup-job.yaml
+++ b/charts/quay/templates/quay-setup-job.yaml
@@ -37,6 +37,6 @@ spec:
           name: ansible-rfe-runner
       dnsPolicy: ClusterFirst
       restartPolicy: OnFailure
-      serviceAccount: rfe-automation
-      serviceAccountName: rfe-automation
+      serviceAccount: {{ .Values.serviceAccount }}
+      serviceAccountName: {{ .Values.serviceAccount }}
       terminationGracePeriodSeconds: 30

--- a/charts/quay/templates/quay-setup-job.yaml
+++ b/charts/quay/templates/quay-setup-job.yaml
@@ -1,14 +1,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  annotations:
-    helm.sh/hook: post-install
-    helm.sh/hook-delete-policy: hook-succeeded
   labels:
     {{- include "common.labels.labels" . | nindent 4 }}
     run: quay-setup-ansible-job
+  annotations:
+    {{- toYaml .Values.setupJob.annotations | nindent 4 }}
   name: quay-setup-ansible-job
-  namespace: rfe
+  namespace: {{.Values.setupJob.namespace}}
 spec:
   template:
     spec:

--- a/charts/quay/templates/quayappsubscription.yaml
+++ b/charts/quay/templates/quayappsubscription.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     {{- toYaml .Values.subscription.annotations | nindent 4 }}  
 spec:
-  channel: quay-v3.5
+  channel: {{ .Values.subscription.channel }}
   installPlanApproval: Automatic
   name: quay-operator
   source: redhat-operators

--- a/charts/quay/templates/quayregistry.yaml
+++ b/charts/quay/templates/quayregistry.yaml
@@ -2,7 +2,7 @@ apiVersion: quay.redhat.com/v1
 kind: QuayRegistry
 metadata:
   name: {{ template "common.names.fullname" . }}
-  namespace: {{ template "common.names.namespace" $ }}
+  namespace: {{ .Values.quayRegistryCR.targetNamespace }}
   labels:
     {{- include "common.labels.labels" . | nindent 4 }}
   annotations:

--- a/charts/quay/templates/rfe-automation-role-quay.yaml
+++ b/charts/quay/templates/rfe-automation-role-quay.yaml
@@ -3,7 +3,7 @@ kind: Role
 metadata:
   labels:
     {{- include "common.labels.labels" . | nindent 4 }}
-  name: rfe-automation-quay
+  name: {{ .Values.serviceAccount }}-quay
   namespace: {{ .Values.quayRegistryCR.targetNamespace }}
   annotations:
     {{- toYaml .Values.setupJob.annotations | nindent 4 }}  

--- a/charts/quay/templates/rfe-automation-role-quay.yaml
+++ b/charts/quay/templates/rfe-automation-role-quay.yaml
@@ -4,7 +4,9 @@ metadata:
   labels:
     {{- include "common.labels.labels" . | nindent 4 }}
   name: rfe-automation-quay
-  namespace: {{ template "common.names.namespace" $ }}
+  namespace: {{ .Values.quayRegistryCR.targetNamespace }}
+  annotations:
+    {{- toYaml .Values.setupJob.annotations | nindent 4 }}  
 rules:
   - apiGroups:
       - "*"

--- a/charts/quay/templates/rfe-automation-rolebinding-quay.yaml
+++ b/charts/quay/templates/rfe-automation-rolebinding-quay.yaml
@@ -3,15 +3,15 @@ kind: RoleBinding
 metadata:
   labels:
     {{- include "common.labels.labels" . | nindent 4 }}
-  name: rfe-automation-quay
+  name: {{ .Values.serviceAccount }}-quay
   namespace: {{ .Values.quayRegistryCR.targetNamespace }}
   annotations:
     {{- toYaml .Values.setupJob.annotations | nindent 4 }}  
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: rfe-automation-quay
+  name: {{ .Values.serviceAccount }}-quay
 subjects:
   - kind: ServiceAccount
-    name: rfe-automation
-    namespace: {{.Values.setupJob.namespace}}
+    name: {{ .Values.serviceAccount }}
+    namespace: {{.Values.setupJob.namespace }}

--- a/charts/quay/templates/rfe-automation-rolebinding-quay.yaml
+++ b/charts/quay/templates/rfe-automation-rolebinding-quay.yaml
@@ -4,7 +4,9 @@ metadata:
   labels:
     {{- include "common.labels.labels" . | nindent 4 }}
   name: rfe-automation-quay
-  namespace: {{ template "common.names.namespace" $ }}
+  namespace: {{ .Values.quayRegistryCR.targetNamespace }}
+  annotations:
+    {{- toYaml .Values.setupJob.annotations | nindent 4 }}  
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -12,4 +14,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: rfe-automation
-    namespace: rfe
+    namespace: {{.Values.setupJob.namespace}}

--- a/charts/quay/values.yaml
+++ b/charts/quay/values.yaml
@@ -22,7 +22,7 @@ subscription:
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": hook-failed
-  channel: stable-3.6
+  channel: quay-v3.5
 
 quayRegistryCR:
   annotations:
@@ -36,3 +36,5 @@ setupJob:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: hook-succeeded
   namespace: rfe
+
+serviceAccount: rfe-automation

--- a/charts/quay/values.yaml
+++ b/charts/quay/values.yaml
@@ -22,11 +22,12 @@ subscription:
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": hook-failed
-
+  channel: stable-3.6
 
 quayRegistryCR:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  targetNamespace: quay
 
 setupJob:
   gitRepository: https://github.com/redhat-cop/rhel-edge-automation-arch.git

--- a/charts/quay/values.yaml
+++ b/charts/quay/values.yaml
@@ -21,6 +21,8 @@ quay:
 subscription:
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-failed
+
 
 quayRegistryCR:
   annotations:
@@ -29,3 +31,7 @@ quayRegistryCR:
 setupJob:
   gitRepository: https://github.com/redhat-cop/rhel-edge-automation-arch.git
   gitBranch: main
+  annotations:
+    helm.sh/hook: post-install
+    helm.sh/hook-delete-policy: hook-succeeded
+  namespace: rfe


### PR DESCRIPTION
* Pins Quay CR to `quay` namespace.
* ~~Updates quay subscription to `stable-3.6`.~~
* Pins `quay-setup` job and related role and rolebinding to the `rfe` namespace.

@sabre1041 @nasx let me know what you think about this.