### PR TITLE
Force RHEL subscription and allow multiple certs instances

### DIFF
--- a/ansible/playbooks/configure-image-builder.yaml
+++ b/ansible/playbooks/configure-image-builder.yaml
@@ -47,28 +47,28 @@
 
     - name: Find Entitlement Key
       ansible.builtin.find:
-        paths: /tmp/rhsm/certs
+        paths: /tmp/rhsm/certs/
         use_regex: yes
         patterns:
           - "^[0-9]+-key.pem$"
       become: no
       delegate_to: localhost
       failed_when:
-        - find_key.matched != 1
-        - find_key.examined != 2
+        - find_key.matched == 0
+        - find_key.examined < 2
       register: find_key
 
     - name: Find Entitlement Cert
       ansible.builtin.find:
-        paths: /tmp/rhsm/certs
+        paths: /tmp/rhsm/certs/
         use_regex: yes
         patterns:
           - "^[0-9]+.pem$"
       become: no
       delegate_to: localhost
       failed_when:
-        - find_cert.matched != 1
-        - find_cert.examined != 2
+        - find_cert.matched == 0
+        - find_cert.examined < 2
       register: find_cert
 
     - name: Create Entitlement Secret

--- a/ansible/roles/image-builder/tasks/main.yaml
+++ b/ansible/roles/image-builder/tasks/main.yaml
@@ -4,6 +4,8 @@
     username: "{{ lookup('file', '/var/secrets/redhat-portal-credentials/username') }}"
     password: "{{ lookup('file', '/var/secrets/redhat-portal-credentials/password') }}"
     pool_ids: "{{ lookup('file', '/var/secrets/redhat-portal-credentials/pool_id') }}"
+    auto_attach: yes
+    force_register: yes
 
 - name: Setup Repositories
   community.general.rhsm_repository:


### PR DESCRIPTION
* Forces the subscription on the VM using the provided credentials/poolID, even if it has already been subscribed.
* Allows the use case where multiple entitlement files exist in `/etc/pki/entitlement`. This is the case after I re-subscribed using my own credentials.
```
rhsm/certs:
total 84
drwxr-xr-x. 2 1000670000 root   138 Nov 30 21:20 .
drwxr-xr-x. 5 1000670000 root    41 Nov 30 21:21 ..
-rw-r--r--. 1 1000670000 root  3247 Nov 30 21:20 1666335240653499028-key.pem
-rw-r--r--. 1 1000670000 root  7717 Nov 30 21:20 1666335240653499028.pem
-rw-r--r--. 1 1000670000 root  3247 Nov 30 21:19 6861774457071742926-key.pem
-rw-r--r--. 1 1000670000 root 67859 Nov 30 21:19 6861774457071742926.pem
```

@sabre1041 @nasx please review.