### PR TITLE
Adding httpd-prepare/rpm-file-permissions commands to Dockerfile.

### DIFF
--- a/charts/httpd/templates/httpd-ostree-buildconfig.yaml
+++ b/charts/httpd/templates/httpd-ostree-buildconfig.yaml
@@ -26,7 +26,8 @@ spec:
         dnf update -y && \
         dnf install -y ostree && \
         rm -rf /etc/pki/entitlement && \
-        rm -rf /etc/rhsm
+        rm -rf /etc/rhsm && \
+        /usr/libexec/httpd-prepare && rpm-file-permissions
       USER 1001
     secrets:
     - destinationDir: etc-pki-entitlement


### PR DESCRIPTION
Fixes permissions issue (error below) after adding additional packages to base image.

```
(13)Permission denied: AH00058: Error retrieving pid file run/httpd.pid
AH00059: Remove it before continuing if it is corrupted.
```