### PR TITLE
Backporting oci-publish-content URL fix

### DIFF
--- a/ansible/roles/oci-publish-content/tasks/main.yaml
+++ b/ansible/roles/oci-publish-content/tasks/main.yaml
@@ -20,7 +20,7 @@
 
 - name: Wait for Stage Deployment
   ansible.builtin.uri:
-    url: "http://{{ quay_image_path_basename }}-{{ quay_image_tag }}-httpd.rfe.svc.cluster.local/repo"
+    url: "http://{{ quay_image_path_basename }}-{{ quay_image_tag }}-httpd.rfe.svc.cluster.local/repo/config"
   delay: 10
   retries: 60
 


### PR DESCRIPTION
This change was pushed to the `helm-migration` branch but should have been pushed instead to the `main` branch:

https://github.com/redhat-cop/rhel-edge-automation-arch/commit/f51317535e8921b5d2f3b995c46a393cfcb075ea#diff-ef37563eaad006b64f5cbed86d65e88a201bed4540857c3faa4302b02d2ae5c4R23

```bash
sh-4.2$ curl http://hello-world-latest-httpd.rfe.svc.cluster.local/repo -L
curl: (7) Failed connect to hello-world-latest-httpd.rfe.svc.cluster.local:8080; No route to host
```

```bash
sh-4.2$ curl http://hello-world-latest-httpd.rfe.svc.cluster.local/repo/config -L
[core]
repo_version=1
mode=archive-z2
```

@nasx @sabre1041 please take a look.

/Jordi
