### PR TITLE
ArgoCD and Tekton enhancements

### DIFF
--- a/charts/argocd/templates/argocd.yaml
+++ b/charts/argocd/templates/argocd.yaml
@@ -138,3 +138,8 @@ spec:
         hs.status = "Progressing"
         hs.message = "Waiting for Build to complete"
         return hs
+  resourceExclusions: |
+    - apiGroups:
+      - tekton.dev
+      kinds:
+      - PipelineRun

--- a/charts/rfe-pipelines/templates/config-defaults-configmap.yaml
+++ b/charts/rfe-pipelines/templates/config-defaults-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   default-service-account: pipeline
-  default-timeout-minutes: "120"
+  default-timeout-minutes: {{ .Values.defaultsConfigmap.timeoutMinutes | quote }}
 kind: ConfigMap
 metadata:
   annotations:

--- a/charts/rfe-pipelines/values.yaml
+++ b/charts/rfe-pipelines/values.yaml
@@ -3,6 +3,7 @@ defaultsConfigmap:
   annotations:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
+  timeoutMinutes: "180"
 
 commonCR:
   annotations:


### PR DESCRIPTION
Extended the default Tekton timeout along with avoiding pruning by ArgoCD for Tekton resources