### PR TITLE
Allow the user to skip the minimal space protection of ostree

### DIFF
--- a/ansible/roles/oci-publish-content/tasks/main.yaml
+++ b/ansible/roles/oci-publish-content/tasks/main.yaml
@@ -37,6 +37,14 @@
       - "init"
       - "--mode=archive"
 
+- name: Set free space percentage to 0
+  ansible.builtin.lineinfile:
+    path: "{{ repo_remote_path }}/config"
+    insertafter: "[core]"
+    firstmatch: yes
+    line: "min-free-space-percent=0"
+  when: skip_free_space_protection | default(false) | bool
+
 - name: Add Remote OSTree Repository
   ansible.builtin.command:
     argv:

--- a/charts/rfe-pipelines/templates/rfe-oci-publish-content-pipeline.yaml
+++ b/charts/rfe-pipelines/templates/rfe-oci-publish-content-pipeline.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "common.labels.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml .Values.commonCR.annotations | nindent 4 }}    
+    {{- toYaml .Values.commonCR.annotations | nindent 4 }}
   name: rfe-oci-publish-content-pipeline
 spec:
   params:
@@ -22,6 +22,10 @@ spec:
       type: string
     - name: image-tag
       description: Tag Associated with the RFE Image to Deploy
+      type: string
+    - name: skip-free-space-protection
+      description: Instruct OSTree to skip its free space protection
+      default: "False"
       type: string
   results:
     - name: content-path
@@ -53,6 +57,8 @@ spec:
           value: $(params.image-path)
         - name: image-tag
           value: $(params.image-tag)
+        - name: skip-free-space-protection
+          value: $(params.skip-free-space-protection)
       runAfter:
         - "git-clone-tooling"
       workspaces:

--- a/charts/rfe-pipelines/templates/rfe-oci-publish-content-task.yaml
+++ b/charts/rfe-pipelines/templates/rfe-oci-publish-content-task.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "common.labels.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml .Values.commonCR.annotations | nindent 4 }}    
+    {{- toYaml .Values.commonCR.annotations | nindent 4 }}
   name: rfe-oci-publish-content
 spec:
   workspaces:
@@ -15,6 +15,8 @@ spec:
       description: Path to RFE Container Image
     - name: image-tag
       description: Tag Associated with the RFE Image to Deploy
+    - name: skip-free-space-protection
+      description: Instruct OSTree to skip its free space protection
   results:
     - name: content-path
       description: URL to OSTree Content
@@ -29,6 +31,7 @@ spec:
           ansible-playbook \
             -e quay_image_path=$(params.image-path) \
             -e quay_image_tag=$(params.image-tag) \
+            -e skip_free_space_protection=$(params.skip-free-space-protection) \
             -e content_path_output_file=$(results.content-path.path) \
             playbooks/oci-publish-content.yaml
       command:


### PR DESCRIPTION
Add a Pipeline parameter called skip-free-space-protection with default False
Pass the parameter from the Pipeline to the Playbook through the Task
In the Playbook, if set, add "min-free-space-percent=0" to the repo's config file