### PR TITLE
Renamed composer types for RHEL to align with release 8.5

### DIFF
--- a/ansible/roles/build-rpm-ostree/tasks/main.yaml
+++ b/ansible/roles/build-rpm-ostree/tasks/main.yaml
@@ -51,7 +51,7 @@
   block:
     - name: Compose Image
       command: >
-        composer-cli -j compose start {{ blueprint_name}} rhel-edge-commit
+        composer-cli -j compose start {{ blueprint_name}} edge-commit
       register: composed_image
 
     - name: Set Build Number

--- a/ansible/roles/oci-build-image/tasks/main.yaml
+++ b/ansible/roles/oci-build-image/tasks/main.yaml
@@ -51,7 +51,7 @@
   block:
     - name: Compose Image
       ansible.builtin.command: >
-        composer-cli -j compose start-ostree {{ blueprint_name }} rhel-edge-container
+        composer-cli -j compose start-ostree {{ blueprint_name }} edge-container
       register: composed_image
 
     - name: Set Build Commit ID

--- a/docs/basic-walkthrough.md
+++ b/docs/basic-walkthrough.md
@@ -21,7 +21,7 @@ The following requirements must be satisfied prior to beginning the walk-through
 This walk-through will illustrate the ease of building, publishing and consuming RHEL for Edge content. For the sample use case, an edge node with the [IBM Developer Model Asset Exchange: Weather Forecaster](https://github.com/IBM/MAX-Weather-Forecaster) application running in a container will be built and deployed. This process consists of the following:
 
 * Execute a series of pipelines that:
-  + Use Image Builder to create a custom RHEL for Edge image (OSTree commit) using compose image type `rhel-edge-container`
+  + Use Image Builder to create a custom RHEL for Edge image (OSTree commit) using compose image type `edge-container`
   + Push generated OCI container to Quay
   + Deploy OCI container on OpenShift for staging
   + Synchronize OStree content from web server running on OpenShift for production promotion


### PR DESCRIPTION
In RHEL 8.5, the composer types `rhel-edge-commit` and `rhel-edge-container` have been [renamed](https://www.osbuild.org/guides/user-guide/edge-container+installer.html#building-a-rhel-for-edge-installer) to `edge-commit` and `edge-container` respectivelly.

```bash
$> cat /etc/redhat-release 
Red Hat Enterprise Linux release 8.5 (Ootpa)
$> compose types |grep edge
edge-commit
edge-container
edge-installer
edge-raw-image
edge-simplified-installer
```
