### PR TITLE
Fix quay subscription channel for 3.6

### DIFF
--- a/charts/bootstrap/values.yaml
+++ b/charts/bootstrap/values.yaml
@@ -186,7 +186,7 @@ application-manager:
                           argocd.argoproj.io/sync-wave: "0"
                         values:
                           operator:
-                            channel: quay-v3.6
+                            channel: stable-3.6
                             installPlanApproval: Automatic
                             name: quay-operator
                             source: redhat-operators


### PR DESCRIPTION
Fixes the subscription channel for quay 3.6. It turns out that the quay operator's channel name has changed from quay v3.5 to v3.6:

![image](https://user-images.githubusercontent.com/19480463/151437319-392c6a1b-962a-4050-9750-6f0ac9294d31.png)


@nasx @sabre1041 please take a look.