### PR TITLE
Adds tls kind to quayregistry

### DIFF
--- a/charts/quay/values.yaml
+++ b/charts/quay/values.yaml
@@ -1,8 +1,6 @@
 ---
 quay:
   components:
-    - kind: clair
-      managed: true
     - kind: horizontalpodautoscaler
       managed: true
     - kind: mirror
@@ -16,6 +14,10 @@ quay:
     - kind: redis
       managed: true
     - kind: route
+      managed: true
+    - kind: tls
+      managed: true
+    - kind: clair
       managed: true
 
 quayRegistryCR:


### PR DESCRIPTION
Fixes an issue in Quay 3.6 where the kind `tls` is automatically added by default to the `quayregistry`. Without this new addition, the quay namespace is in a continuous flux of pods being created/deleted as argocd and the operator deliver a never ending conflict where the poor pods, being at the end of the stick, are getting killed while their overlords exchange holds over who controls the CR.

@sabre1041 @nasx please take a look at your discretion.