### PR TITLE
Pass extra ansible vars to kickstart task

### DIFF
--- a/charts/rfe-pipelines/templates/rfe-kickstart-pipeline.yaml
+++ b/charts/rfe-pipelines/templates/rfe-kickstart-pipeline.yaml
@@ -31,6 +31,9 @@ spec:
     - name: kickstart-path
       description: Path containing the kickstart
       type: string
+    - name: extra-template-values
+      description: Additional template values to be replaced in the kickstart.ks 
+      type: string      
   workspaces:
     - name: shared-workspace
   tasks:
@@ -73,6 +76,8 @@ spec:
           value: /workspace/workspace/kickstarts/$(params.kickstart-path)
         - name: kickstart-destination-dir
           value: /workspace/workspace/kickstarts
+        - name: extra-ansible-variables
+          value: $(params.extra-template-values)
       runAfter:
         - "git-clone-kickstarts"
         - "git-clone-tooling"


### PR DESCRIPTION
Adds a parameter to the `rfe-kickstart-pipeline` to allow passing additional values to ansible to be used during the template parsing of the kickstart file. This will allow customizing the kickstart file further than just the ostree url.

@nasx @sabre1041 can you take a look?