### PR TITLE
Adds tls kind and IgnoreExtraneous to quayregistry

### DIFF
--- a/charts/quay/values.yaml
+++ b/charts/quay/values.yaml
@@ -17,10 +17,14 @@ quay:
       managed: true
     - kind: route
       managed: true
+    - kind: tls
+      managed: true
+
 
 quayRegistryCR:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
   targetNamespace: quay
 
 setupJob:


### PR DESCRIPTION
Fixes an issue in Quay 3.6 where the kind tls is automatically added by default to the quayregistry. Without this new addition, the quay namespace is in a continuous flux of pods being created/deleted as argocd and the operator deliver a never ending conflict where the poor pods, being at the end of the stick, are getting killed while their overlords exchange holds over who controls the CR.

Also adds the ArgoCD annotation `IgnoreExtraneous` to ignore any changes in the order of objects listed in the CR, since the list changes in order as the object is updated by the operator. Note that this also means further changes in the contents of the object by the operator, such as new fields,  are no longer monitored by ArgoCD.
 
Solves #241

@sabre1041 @nasx please take a look at your discretion.